### PR TITLE
bug fixes in io

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This is an intermediate format used by hickit to store raw contacts directly
 inferred from read alignment. It is generally adviced to convert this format to
 pairs with:
 ```sh
-./hickit -i contacts.seg.gz --keep-dup --min-leg-dist=0 -o contacts.pairs
+./hickit --dup-dist=0 --min-leg-dist=0 -i contacts.seg.gz -o contacts.pairs
 ```
 
 ### <a name="gen-pairs"></a>Generating contacts in the pairs format

--- a/io.c
+++ b/io.c
@@ -241,7 +241,7 @@ void hk_map_set_cols(struct hk_map *m, int n_extra_cols, int *extra_cols)
 		for (i = 0, t[0] = t[1] = 0; i < m->n_segs; ++i) {
 			if (m->segs[i].phase >= 0 && m->segs[i].phase <= 1)
 				t[m->segs[i].phase] = 1;
-			if (t[0] && t[1]) break;
+			if (t[0] || t[1]) break;
 		}
 		if (i < m->n_segs) m->cols |= 3;
 	} else if (m->pairs) {
@@ -253,7 +253,7 @@ void hk_map_set_cols(struct hk_map *m, int n_extra_cols, int *extra_cols)
 		for (i = 0, t[0] = t[1] = 0; i < m->n_pairs; ++i) {
 			if (m->pairs[i].phase[0] >= 0) t[0] = 1;
 			if (m->pairs[i].phase[1] >= 0) t[1] = 1;
-			if (t[0] && t[1]) break;
+			if (t[0] || t[1]) break;
 		}
 		if (i < m->n_pairs) m->cols |= 3;
 	}


### PR DESCRIPTION
note that arguments such as `--max-seg` and `--dup-dist` only work if ordered first; not sure if the behavior is intended